### PR TITLE
refactor: move inline styles to external CSS

### DIFF
--- a/construction.html
+++ b/construction.html
@@ -108,8 +108,7 @@
             <div class="relative isolate px-6 pt-14 lg:px-8">
                 <div class="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
                     aria-hidden="true">
-                    <div class="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-30 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]"
-                        style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)">
+                    <div class="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-30 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem] clip-polygon">
                     </div>
                 </div>
                 <div class="mx-auto max-w-3xl  py-20">
@@ -138,8 +137,7 @@
                 
                 <div class="absolute  inset-x-0 top-[calc(100%-13rem)] -z-10 transform-gpu overflow-hidden blur-3xl sm:top-[calc(100%-30rem)]"
                     aria-hidden="true">
-                    <div class="relative left-[calc(50%+3rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-20 sm:left-[calc(50%+36rem)] sm:w-[72.1875rem]"
-                        style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)">
+                    <div class="relative left-[calc(50%+3rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-20 sm:left-[calc(50%+36rem)] sm:w-[72.1875rem] clip-polygon">
                     </div>
                 </div>
             </div>

--- a/contact.html
+++ b/contact.html
@@ -141,7 +141,7 @@
                                 class="w-full px-4 py-3 bg-[#1c1c1c] border border-[cyan] rounded-lg focus:outline-none focus:border-blue-500"
                                 required></textarea>
                         </div>
-                        <input type="checkbox" name="botcheck" class="hidden" style="display: none;">
+                        <input type="checkbox" name="botcheck" class="hidden">
                        
                         <input type="hidden" name="redirect" value="https://aero2astro.com/tech">
                         <!-- Submit Button -->

--- a/energy.html
+++ b/energy.html
@@ -352,40 +352,12 @@
                 });
             });
         </script>
-        <style>
-            .tab {
-                transition: border-bottom-color 0.3s ease;
-            }
-
-            .tab:hover {
-                background-color: #1c1c1c;
-
-                border-bottom-color: #23a3df;
-
-            }
-
-            .active-tab {
-                background-color: #1c1c1c;
-
-                border-bottom-color: #23a3df;
-
-            }
-
-            .project-description {
-                display: none;
-            }
-
-            .project-description.active {
-                display: block;
-            }
-        </style>
 
 
 
 
         <div data-aos-duration="2000" data-aos="zoom-in"
-            class="md:mx-32 mx-3 py-10 border border-cyan-500 my-20 rounded-3xl"
-            style="background: linear-gradient(190deg, #1c1c1c,#1c1c1c, #075f7a);">
+            class="md:mx-32 mx-3 py-10 border border-cyan-500 my-20 rounded-3xl bg-dark-cyan-gradient">
             <h2 class="text-center my-5 lg:text-4xl text-2xl font-semibold text-white">Partnering for Success</h2>
             <p class="p-10 text-lg text-white"> At Aero2astro, we believe in forging strong partnerships with our
                 clients. We work closely with solar & windmill

--- a/engineering.html
+++ b/engineering.html
@@ -108,8 +108,7 @@
             <div class="relative isolate px-6 pt-14 lg:px-8">
                 <div class="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
                     aria-hidden="true">
-                    <div class="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-30 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]"
-                        style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)">
+                    <div class="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-30 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem] clip-polygon">
                     </div>
                 </div>
                 <div class="mx-auto max-w-3xl  py-20">
@@ -141,8 +140,7 @@
 
                 <div class="absolute inset-x-0 top-[calc(100%-13rem)] -z-10 transform-gpu overflow-hidden blur-3xl sm:top-[calc(100%-30rem)]"
                     aria-hidden="true">
-                    <div class="relative left-[calc(50%+3rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-20 sm:left-[calc(50%+36rem)] sm:w-[72.1875rem]"
-                        style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)">
+                    <div class="relative left-[calc(50%+3rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-20 sm:left-[calc(50%+36rem)] sm:w-[72.1875rem] clip-polygon">
                     </div>
                 </div>
             </div>

--- a/index.css
+++ b/index.css
@@ -36,15 +36,11 @@
     white-space: nowrap;
   }
   
-  .marquee {
-      display:  inline-block;
-      white-space: nowrap;
-      position: relative;
-      transform: translate3d(0%, 0, 0);
-      animation-name: marquee;
-      animation-timing-function: linear;
-      animation-iteration-count: infinite;
-  }
+.marquee {
+    overflow: hidden;
+    position: relative;
+    white-space: nowrap;
+}
   
   .marquee a {
       display:  inline-block;
@@ -52,19 +48,30 @@
       padding-right: 5.4rem;
   }
   
-  .marquee-wrapper:hover .marquee {
-      animation-play-state: paused !important;
-  }
+.marquee-wrapper:hover .marquee {
+    animation-play-state: paused !important;
+}
+
+.marquee-content {
+    display: inline-block;
+    white-space: nowrap;
+    will-change: transform;
+    animation: marquee 30s linear infinite;
+}
   
-  @keyframes marquee {
-      0% {
-          transform: translate3d(0%, 0, 0);
-      }
-  
-      100% {
-          transform: translate3d(-100%, 0, 0);
-      }
-  }
+@keyframes marquee {
+    0% {
+        transform: translate3d(0%, 0, 0);
+    }
+
+    100% {
+        transform: translate3d(-100%, 0, 0);
+    }
+}
+
+.bg-dark-gradient {
+    background: linear-gradient(190deg, #1c1c1c, #111111, #111111);
+}
 
 
 

--- a/index.html
+++ b/index.html
@@ -191,38 +191,7 @@
         </section>
 
 
-        <style>
-            .marquee {
-                overflow: hidden;
-                position: relative;
-                white-space: nowrap;
-            }
-
-            .marquee-content {
-
-                white-space: nowrap;
-                will-change: transform;
-                animation: marquee 30s linear infinite;
-            }
-
-            @keyframes marquee {
-                0% {
-                    transform: translateX(0%);
-                }
-
-                100% {
-                    transform: translateX(-50%);
-                }
-            }
-
-            .logos {
-                max-height: 70px;
-                min-height: 50px;
-                margin: 0 15px;
-            }
-        </style>
-
-
+        
         <!--  marquee styling ends -->
 
 
@@ -288,8 +257,7 @@
 
         <!-- What we Provide -->
         <div data-aos-duration="1000" data-aos="fade-up"
-            class="md:mx-32 mx-3 py-10 my-20 rounded-3xl"
-            style="background: linear-gradient(190deg, #1c1c1c, #111111, #111111);">
+            class="md:mx-32 mx-3 py-10 my-20 rounded-3xl bg-dark-gradient">
             <h2 class="text-center my-5 text-3xl font-bold md:text-5xl text-white">What We Provide</h2>
 
             <div class="p-10 text-lg items-center text-white md:flex md:gap-10">

--- a/infra.html
+++ b/infra.html
@@ -14,6 +14,7 @@
         crossorigin="anonymous" referrerpolicy="no-referrer" />
     <!-- <script src="solutions.js" defer></script> -->
     <link rel="stylesheet" href="./assets/css/header.css">
+    <link rel="stylesheet" href="solutions.css">
     <script src="./assets/js/header.js" defer> </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
@@ -110,8 +111,7 @@
             <div class="relative isolate px-6 pt-14 lg:px-8">
                 <div class="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
                     aria-hidden="true">
-                    <div class="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-30 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]"
-                        style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)">
+                    <div class="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-30 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem] clip-polygon">
                     </div>
                 </div>
                 <div class="mx-auto max-w-5xl  py-20">
@@ -135,8 +135,7 @@
                 </div>
                 <div class="absolute inset-x-0 top-[calc(100%-13rem)] -z-10 transform-gpu overflow-hidden blur-3xl sm:top-[calc(100%-30rem)]"
                     aria-hidden="true">
-                    <div class="relative left-[calc(50%+3rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-20 sm:left-[calc(50%+36rem)] sm:w-[72.1875rem]"
-                        style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)">
+                    <div class="relative left-[calc(50%+3rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-20 sm:left-[calc(50%+36rem)] sm:w-[72.1875rem] clip-polygon">
                     </div>
                 </div>
             </div>
@@ -526,36 +525,10 @@
         </div>
 
 
-        <style>
-            .tabs-content {
-                background: linear-gradient(15deg, #1c1c1c, #111111, #23a3df);
-            }
-        </style>
 
 
         </div>
 
-        <style>
-            .tab-button {
-                transition: all 0.3s ease;
-            }
-
-
-            .tab-content {
-                transition: opacity 0.3s ease;
-            }
-
-            .tab-content.hidden {
-                opacity: 0;
-                pointer-events: none;
-            }
-
-            .tabs-content {
-                display: grid;
-                grid-template-columns: 1fr;
-                gap: 20px;
-            }
-        </style>
 
 
         <script>
@@ -885,16 +858,6 @@
 
     </main>
 
-    <style>
-        .tabc-content-hidden {
-            display: none;
-        }
-
-        .tabc-active {
-            color: #2cace7 !important;
-            border-color: #23a3df;
-        }
-    </style>
 
     <script>
 

--- a/mining.html
+++ b/mining.html
@@ -386,40 +386,11 @@
                 });
             });
         </script>
-        <style>
-           
-
-            .tab {
-                transition: border-bottom-color 0.3s ease;
-            }
-
-            .tab:hover {
-                background-color: #1c1c1c;
-
-                border-bottom-color: #23a3df;
-
-            }
-
-            .active-tab {
-                background-color: #1c1c1c;
-
-                border-bottom-color: #23a3df;
-
-            }
-
-            .project-description {
-                display: none;
-            }
-
-            .project-description.active {
-                display: block;
-            }
-        </style>
 
 
 
 
-        <div data-aos-duration="2000" data-aos="zoom-in" class="md:mx-32 mx-3 py-10 border border-cyan-500 my-20 rounded-3xl" style="background: linear-gradient(190deg, #1c1c1c,#1c1c1c, #075f7a);">
+        <div data-aos-duration="2000" data-aos="zoom-in" class="md:mx-32 mx-3 py-10 border border-cyan-500 my-20 rounded-3xl bg-dark-cyan-gradient">
                         <h2 class="text-center my-5 lg:text-4xl text-2xl font-semibold text-white">Partnering for Success</h2>
             <p class="p-10 text-lg text-white"> At Aero2astro, we believe in forging strong partnerships with our
                 clients. We work closely with mining

--- a/operation.html
+++ b/operation.html
@@ -110,8 +110,7 @@
             <div class="relative isolate px-6 pt-14 lg:px-8">
                 <div class="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
                     aria-hidden="true">
-                    <div class="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-30 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]"
-                        style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)">
+                    <div class="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-30 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem] clip-polygon">
                     </div>
                 </div>
                 <div class="mx-auto max-w-3xl  py-20">
@@ -139,8 +138,7 @@
                 
                 <div class="absolute inset-x-0 top-[calc(100%-13rem)] -z-10 transform-gpu overflow-hidden blur-3xl sm:top-[calc(100%-30rem)]"
                     aria-hidden="true">
-                    <div class="relative left-[calc(50%+3rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-20 sm:left-[calc(50%+36rem)] sm:w-[72.1875rem]"
-                        style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)">
+                    <div class="relative left-[calc(50%+3rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 bg-gradient-to-tr from-[#111111] to-[#23a3df] opacity-20 sm:left-[calc(50%+36rem)] sm:w-[72.1875rem] clip-polygon">
                     </div>
                 </div>
             </div>

--- a/solutions.css
+++ b/solutions.css
@@ -2,7 +2,65 @@
 
 .scrollable-section {
     overflow: scroll;
-    
     white-space: nowrap;
+}
+
+.clip-polygon {
+    clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%);
+}
+
+.bg-dark-cyan-gradient {
+    background: linear-gradient(190deg, #1c1c1c,#1c1c1c, #075f7a);
+}
+
+.tab {
+    transition: border-bottom-color 0.3s ease;
+}
+
+.tab:hover {
+    background-color: #1c1c1c;
+    border-bottom-color: #23a3df;
+}
+
+.active-tab {
+    background-color: #1c1c1c;
+    border-bottom-color: #23a3df;
+}
+
+.project-description {
+    display: none;
+}
+
+.project-description.active {
+    display: block;
+}
+
+.tabs-content {
+    background: linear-gradient(15deg, #1c1c1c, #111111, #23a3df);
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 20px;
+}
+
+.tab-button {
+    transition: all 0.3s ease;
+}
+
+.tab-content {
+    transition: opacity 0.3s ease;
+}
+
+.tab-content.hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.tabc-content-hidden {
+    display: none;
+}
+
+.tabc-active {
+    color: #2cace7 !important;
+    border-color: #23a3df;
 }
 

--- a/utilities.html
+++ b/utilities.html
@@ -356,40 +356,12 @@
                 });
             });
         </script>
-        <style>
-            .tab {
-                transition: border-bottom-color 0.3s ease;
-            }
-
-            .tab:hover {
-                background-color: #1c1c1c;
-
-                border-bottom-color: #23a3df;
-
-            }
-
-            .active-tab {
-                background-color: #1c1c1c;
-
-                border-bottom-color: #23a3df;
-
-            }
-
-            .project-description {
-                display: none;
-            }
-
-            .project-description.active {
-                display: block;
-            }
-        </style>
 
 
 
 
         <div data-aos-duration="2000" data-aos="zoom-in"
-            class="md:mx-32 mx-3 py-10 border border-cyan-500 my-20 rounded-3xl"
-            style="background: linear-gradient(190deg, #1c1c1c,#1c1c1c, #075f7a);">
+            class="md:mx-32 mx-3 py-10 border border-cyan-500 my-20 rounded-3xl bg-dark-cyan-gradient">
             <h2 class="text-center my-5 lg:text-4xl text-2xl font-semibold text-white">Partnering for Success</h2>
             <p class="p-10 text-lg text-white"> At Aero2astro, we believe in forging strong partnerships with our
                 clients. We work closely with mining, solar, windmill and more


### PR DESCRIPTION
## Summary
- migrate marquee and gradient styles into `index.css`
- centralize polygon, gradient, and tab styling in `solutions.css`
- clean up pages to rely on shared classes instead of inline styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b046af79988326b00dbd46bfe41683