### PR TITLE
Add canonical redirect rules

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,10 @@
+RewriteEngine On
+
+# Redirect www to non-www and force HTTPS
+RewriteCond %{HTTPS} !=on [OR]
+RewriteCond %{HTTP_HOST} ^www\.aero2astro\.com$ [NC]
+RewriteRule ^(.*)$ https://aero2astro.com/$1 [L,R=301]
+
+# Redirect index.html to root
+RewriteCond %{THE_REQUEST} \s/+index\.html [NC]
+RewriteRule ^index\.html$ https://aero2astro.com/ [L,R=301]


### PR DESCRIPTION
## Summary
- enforce HTTPS and non-www URL
- redirect index.html to site root

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b06c049b888326bcb024e3c9c42786