### PR TITLE
Add AddThis social sharing buttons

### DIFF
--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -43,3 +43,20 @@ document.addEventListener('DOMContentLoaded', () => {
   gtag('js', new Date());
   gtag('config', GA_MEASUREMENT_ID);
 })();
+
+// AddThis social sharing buttons
+document.addEventListener('DOMContentLoaded', () => {
+  const shareContainer = document.createElement('div');
+  shareContainer.className = 'addthis_inline_share_toolbox mt-4';
+  const footer = document.querySelector('footer');
+  if (footer) {
+    footer.appendChild(shareContainer);
+  } else {
+    document.body.appendChild(shareContainer);
+  }
+
+  const addthisScript = document.createElement('script');
+  addthisScript.src = 'https://s7.addthis.com/js/300/addthis_widget.js#pubid=ra-1234567890';
+  addthisScript.async = true;
+  document.body.appendChild(addthisScript);
+});


### PR DESCRIPTION
## Summary
- inject AddThis social sharing toolkit and script via header.js to connect pages with social networks

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b06d6bba3c8326957262dae74246b7