### PR TITLE
Add social media share widget via AddThis

### DIFF
--- a/index.html
+++ b/index.html
@@ -1351,20 +1351,24 @@
               <div class="p-5 md:px-10 border-t-[1px] border-t-[#209dd8]">
                 <p class="font-thin text-center">Copyright &copy; 2024 <a target="_blank" href="https://aero2astro.com" class="font-semibold text-[#209dd8]">
                 Aero2Astro </a></p>
+                <div class="flex justify-center mt-4">
+                  <div class="addthis_inline_share_toolbox"></div>
+                </div>
               </div>
       
         
       
       </footer>
-          
+
     </div>
 
-   
+
     <!--<script src="https://unpkg.com/aos@next/dist/aos.js" ></script>-->
 
     <!--<script>-->
     <!--    AOS.init();-->
     <!--</script>-->
+    <script type="text/javascript" src="https://s7.addthis.com/js/300/addthis_widget.js#pubid=ra-0000000000000000"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- add AddThis inline share toolbox in footer
- load AddThis widget script to enable social sharing

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b06fcd44808326a9f17d7d59c4e63c